### PR TITLE
Trying to strict build

### DIFF
--- a/src/ngx_postgres_output.c
+++ b/src/ngx_postgres_output.c
@@ -207,13 +207,12 @@ ngx_postgres_output_hex(ngx_http_request_t *r, PGresult *res)
 
     char *value = PQgetvalue(res, 0, 0);
 
-    int start = 0;
+    unsigned int start = 0;
     if (value[start] == '\\')
         start++;
     if (value[start] == 'x')
         start++;
 
-    int i = 0;
     for (; start < size; start += 2)
         *(b->last++) = hex2bin(value + start);
     //if (b->last != b->end) {
@@ -858,7 +857,7 @@ ngx_postgres_output_json(ngx_http_request_t *r, PGresult *res)
             ngx_str_t export_variable;
             for (col = 0; col < col_count; col++) {
                 char *col_name = PQfname(res, col);
-                export_variable.data = col_name;
+                export_variable.data = (u_char *)col_name;
                 export_variable.len = strlen(col_name);
 
                 ngx_uint_t meta_variable_hash = ngx_hash_key(export_variable.data, export_variable.len);
@@ -869,7 +868,7 @@ ngx_postgres_output_json(ngx_http_request_t *r, PGresult *res)
                     char *exported_value = ngx_palloc(r->main->pool, exported_length);
                     ngx_memcpy(exported_value, PQgetvalue(res, 0, col), exported_length);
                     raw_meta->len = exported_length;
-                    raw_meta->data = exported_value;
+                    raw_meta->data = (u_char *)exported_value;
                 }
             }
         }

--- a/src/ngx_postgres_processor.c
+++ b/src/ngx_postgres_processor.c
@@ -235,7 +235,7 @@ done:
 }
 
 
-bool is_variable_character(char *p) {
+bool is_variable_character(u_char *p) {
     return ((*p >= '0' && *p <= '9') || 
             (*p >= 'a' && *p <= 'z') ||
             (*p >= 'A' && *p <= 'Z') || *p == '_');
@@ -372,7 +372,7 @@ int generate_prepared_query(ngx_http_request_t *r, char *query, u_char *data, in
                     int i = 0;
                     for (; i < *paramnum; i++) {
                         if (strncmp(names[i], (char *) p, f - p) == 0
-                        && !is_variable_character(names[i] + (f - p))) {
+                        && !is_variable_character((u_char *) names[i] + (f - p))) {
                             break;
                         }
                     }
@@ -460,7 +460,7 @@ int generate_prepared_query(ngx_http_request_t *r, char *query, u_char *data, in
                     int i = 0;
                     for (; i < *paramnum; i++) {
                         if (strncmp(names[i], (char *) p, f - p) == 0
-                        && !is_variable_character(names[i] + (f - p))) {
+                        && !is_variable_character((u_char *) names[i] + (f - p))) {
                             break;
                         }
                     }

--- a/src/ngx_postgres_rewrite.c
+++ b/src/ngx_postgres_rewrite.c
@@ -187,7 +187,7 @@
         url_variable.len = 0;
         //fprintf(stdout, "something here %s\n", p);
 
-        while(url_variable.len < (redirect + size) - (p + 1)) {
+        while((u_char *) url_variable.len < (redirect + size) - (p + 1)) {
           u_char *n = url_variable.data + url_variable.len;
           if (*n == '\0' || *n == '=' || *n == '&' || *n == '-' || *n == '%' || *n == '/' || *n == '#' || *n == '?' || *n == ':')
             break;
@@ -467,7 +467,6 @@ ngx_postgres_rewrite_valid(ngx_http_request_t *r,
       values[i] = columned[i] = variables[i] = NULL;
     }
     
-    int size = 0;
     // find callback
     if (pgrcf->methods_set & r->method) {
       rewrite = pgrcf->methods->elts;

--- a/src/ngx_postgres_rewrite.c
+++ b/src/ngx_postgres_rewrite.c
@@ -187,7 +187,7 @@
         url_variable.len = 0;
         //fprintf(stdout, "something here %s\n", p);
 
-        while((u_char *) url_variable.len < (redirect + size) - (p + 1)) {
+        while(url_variable.len < (redirect + size) - (p + 1)) {
           u_char *n = url_variable.data + url_variable.len;
           if (*n == '\0' || *n == '=' || *n == '&' || *n == '-' || *n == '%' || *n == '/' || *n == '#' || *n == '?' || *n == ':')
             break;


### PR DESCRIPTION
```
debian/extra/ngx_postgres/src/ngx_postgres_rewrite.c:190:43: error: comparison between pointer and integer [-Werror]
         while(url_variable.len < (redirect + size) - (p + 1)) {
                                           ^
debian/extra/ngx_postgres/src/ngx_postgres_rewrite.c: In function 'ngx_postgres_rewrite':
debian/extra/ngx_postgres/src/ngx_postgres_rewrite.c:346:40: error: initialization makes integer from pointer without a cast [-Werror=int-conversion]
debian/extra/ngx_postgres/src/ngx_postgres_rewrite.c: In function 'ngx_postgres_rewrite':
debian/extra/ngx_postgres/src/ngx_postgres_rewrite.c:346:40: error: initialization makes integer from pointer without a cast [-Werror=int-conversion]
                           char error = ngx_postgres_find_values(values, variables, vars, columned, pgctx, 1);
                                        ^
debian/extra/ngx_postgres/src/ngx_postgres_rewrite.c:346:32: error: unused variable 'error' [-Werror=unused-variable]
                           char error = ngx_postgres_find_values(values, variables, vars, columned, pgctx, 1);
```
I build with:  
```cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fstack-protector-strong -Wformat -Werror=format-security  -D_GLIBCXX_USE_CXX11_ABI=0 -DNDK_SET_VAR -Wno-deprecated-declarations```
Basically, I stopped editing since I can't figure out how unused `*error` should works.
Please, review commits changes (I can beautify commit after if you need it)
Surely its annoying to fix all this warnings, so I thinking, maybe you could use some fixes from this commit. But as I already said, its not finished, and I have no idea, how much beside this 3 warnings remains.